### PR TITLE
Hyphen in Sentence Split

### DIFF
--- a/rake.py
+++ b/rake.py
@@ -54,7 +54,7 @@ def split_sentences(text):
     Utility function to return a list of sentences.
     @param text The text that must be split in to sentences.
     """
-    sentence_delimiters = re.compile(u'[.!?,;:\t\\-\\"\\(\\)\\\'\u2019\u2013]')
+    sentence_delimiters = re.compile(u'[.!?,;:\t\\\\"\\(\\)\\\'\u2019\u2013]|\s\-\s')
     sentences = sentence_delimiters.split(text)
     return sentences
 


### PR DESCRIPTION
A hyphen with spaces around it should be treated as sentence delimiters. However, a hyphen without space around it should be excluded in sentence delimiters. Otherwise, "high-performance", a hyphenated word, will be split incorrectly. 
